### PR TITLE
Rename msgpack-python -> msgpack

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
-{% set name = "msgpack-python" %}
+{% set name = "msgpack" %}
 {% set version = "0.5.6" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
 {% set hash = "378cc8a6d3545b532dfd149da715abae4fda2a3adb6d74e525d0d5e51f46909b" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
msgpack-python has been renamed to msgpack in PyPI.